### PR TITLE
Fix Azure Service Bus source: use lightweight JRE for simple-send

### DIFF
--- a/connect/connect-azure-service-bus-source/QueuesGettingStarted/Dockerfile
+++ b/connect/connect-azure-service-bus-source/QueuesGettingStarted/Dockerfile
@@ -1,6 +1,4 @@
-ARG CP_CONNECT_TAG
-ARG CP_CONNECT_IMAGE
-FROM ${CP_CONNECT_IMAGE}:${CP_CONNECT_TAG}
+FROM eclipse-temurin:11-jre
 COPY ./target/*.jar ./
 ENV JAVA_OPTS ""
 CMD sleep infinity

--- a/connect/connect-azure-service-bus-source/QueuesGettingStarted/pom.xml
+++ b/connect/connect-azure-service-bus-source/QueuesGettingStarted/pom.xml
@@ -47,9 +47,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-servicebus</artifactId>
-            <version>3.6.7</version>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-messaging-servicebus</artifactId>
+            <version>7.17.14</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/connect/connect-azure-service-bus-source/QueuesGettingStarted/src/main/java/com/microsoft/azure/servicebus/samples/queuesgettingstarted/QueuesGettingStarted.java
+++ b/connect/connect-azure-service-bus-source/QueuesGettingStarted/src/main/java/com/microsoft/azure/servicebus/samples/queuesgettingstarted/QueuesGettingStarted.java
@@ -23,14 +23,6 @@ public class QueuesGettingStarted {
 
     public void run(String connectionString) throws Exception {
 
-        // Create a QueueClient instance for receiving using the connection string builder
-        // We set the receive mode to "PeekLock", meaning the message is delivered
-        // under a lock and must be acknowledged ("completed") to be removed from the queue
-        QueueClient receiveClient = new QueueClient(new ConnectionStringBuilder(connectionString, System.getenv("AZURE_SERVICE_BUS_QUEUE_NAME")), ReceiveMode.PEEKLOCK);
-        // We are using single thread executor as we are only processing one message at a time
-    	ExecutorService executorService = Executors.newSingleThreadExecutor();
-        this.registerReceiver(receiveClient, executorService);
-
         // Create a QueueClient instance for sending and then asynchronously send messages.
         // Close the sender once the send operation is complete.
         QueueClient sendClient = new QueueClient(new ConnectionStringBuilder(connectionString, System.getenv("AZURE_SERVICE_BUS_QUEUE_NAME")), ReceiveMode.PEEKLOCK);
@@ -38,10 +30,6 @@ public class QueuesGettingStarted {
 
         // wait for ENTER or 10 seconds elapsing
         waitForEnter(10);
-
-        // shut down receiver to close the receive loop
-        receiveClient.close();
-        executorService.shutdown();
     }
 
     CompletableFuture<Void> sendMessagesAsync(QueueClient sendClient) {

--- a/connect/connect-azure-service-bus-source/QueuesGettingStarted/src/main/java/com/microsoft/azure/servicebus/samples/queuesgettingstarted/QueuesGettingStarted.java
+++ b/connect/connect-azure-service-bus-source/QueuesGettingStarted/src/main/java/com/microsoft/azure/servicebus/samples/queuesgettingstarted/QueuesGettingStarted.java
@@ -3,16 +3,11 @@
 
 package com.microsoft.azure.servicebus.samples.queuesgettingstarted;
 
-import com.google.gson.reflect.TypeToken;
-import com.microsoft.azure.servicebus.*;
-import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
+import com.azure.messaging.servicebus.*;
 import com.google.gson.Gson;
-
-import static java.nio.charset.StandardCharsets.*;
 
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.*;
 import java.util.function.Function;
 
 import org.apache.commons.cli.*;
@@ -21,90 +16,53 @@ public class QueuesGettingStarted {
 
     static final Gson GSON = new Gson();
 
+    // Scientists data
+    private final Map<String, String>[] scientists = new Map[]{
+        Map.of("name", "Einstein", "firstName", "Albert"),
+        Map.of("name", "Heisenberg", "firstName", "Werner"),
+        Map.of("name", "Curie", "firstName", "Marie"),
+        Map.of("name", "Hawking", "firstName", "Steven"),
+        Map.of("name", "Newton", "firstName", "Isaac"),
+        Map.of("name", "Bohr", "firstName", "Niels"),
+        Map.of("name", "Faraday", "firstName", "Michael"),
+        Map.of("name", "Galilei", "firstName", "Galileo"),
+        Map.of("name", "Kepler", "firstName", "Johannes"),
+        Map.of("name", "Kopernikus", "firstName", "Nikolaus")
+    };
+
     public void run(String connectionString) throws Exception {
 
-        // Create a QueueClient instance for sending and then asynchronously send messages.
-        // Close the sender once the send operation is complete.
-        QueueClient sendClient = new QueueClient(new ConnectionStringBuilder(connectionString, System.getenv("AZURE_SERVICE_BUS_QUEUE_NAME")), ReceiveMode.PEEKLOCK);
-        this.sendMessagesAsync(sendClient).thenRunAsync(() -> sendClient.closeAsync());
+        String queueName = System.getenv("AZURE_SERVICE_BUS_QUEUE_NAME");
 
-        // wait for ENTER or 10 seconds elapsing
-        waitForEnter(10);
-    }
+        // Create a ServiceBusSenderClient for sending messages
+        ServiceBusSenderClient senderClient = new ServiceBusClientBuilder()
+            .connectionString(connectionString)
+            .sender()
+            .queueName(queueName)
+            .buildClient();
 
-    CompletableFuture<Void> sendMessagesAsync(QueueClient sendClient) {
-        List<HashMap<String, String>> data =
-                GSON.fromJson(
-                        "[" +
-                                "{'name' = 'Einstein', 'firstName' = 'Albert'}," +
-                                "{'name' = 'Heisenberg', 'firstName' = 'Werner'}," +
-                                "{'name' = 'Curie', 'firstName' = 'Marie'}," +
-                                "{'name' = 'Hawking', 'firstName' = 'Steven'}," +
-                                "{'name' = 'Newton', 'firstName' = 'Isaac'}," +
-                                "{'name' = 'Bohr', 'firstName' = 'Niels'}," +
-                                "{'name' = 'Faraday', 'firstName' = 'Michael'}," +
-                                "{'name' = 'Galilei', 'firstName' = 'Galileo'}," +
-                                "{'name' = 'Kepler', 'firstName' = 'Johannes'}," +
-                                "{'name' = 'Kopernikus', 'firstName' = 'Nikolaus'}" +
-                                "]",
-                        new TypeToken<List<HashMap<String, String>>>() {}.getType());
-
-        List<CompletableFuture> tasks = new ArrayList<>();
-        for (int i = 0; i < data.size(); i++) {
-            final String messageId = Integer.toString(i);
-            Message message = new Message(GSON.toJson(data.get(i), Map.class).getBytes(UTF_8));
+        // Send messages synchronously
+        for (int i = 0; i < scientists.length; i++) {
+            ServiceBusMessage message = new ServiceBusMessage(GSON.toJson(scientists[i]));
+            message.setMessageId(Integer.toString(i));
             message.setContentType("application/json");
-            message.setLabel("Scientist");
-            message.setMessageId(messageId);
+            message.setSubject("Scientist");
             message.setTimeToLive(Duration.ofMinutes(2));
+
             System.out.printf("\nMessage sending: Id = %s", message.getMessageId());
-            tasks.add(
-                    sendClient.sendAsync(message).thenRunAsync(() -> {
-                        System.out.printf("\n\tMessage acknowledged: Id = %s", message.getMessageId());
-                    }));
+
+            try {
+                senderClient.sendMessage(message);
+                System.out.printf("\n\tMessage acknowledged: Id = %s", message.getMessageId());
+            } catch (Exception e) {
+                System.out.printf("\n\tFailed to send message: Id = %s, Error = %s",
+                                message.getMessageId(), e.getMessage());
+            }
         }
-        return CompletableFuture.allOf(tasks.toArray(new CompletableFuture<?>[tasks.size()]));
-    }
 
-    void registerReceiver(QueueClient queueClient, ExecutorService executorService) throws Exception {
-
-
-        // register the RegisterMessageHandler callback with executor service
-        queueClient.registerMessageHandler(new IMessageHandler() {
-                                               // callback invoked when the message handler loop has obtained a message
-                                               public CompletableFuture<Void> onMessageAsync(IMessage message) {
-                                                   // receives message is passed to callback
-                                                   if (message.getLabel() != null &&
-                                                           message.getContentType() != null &&
-                                                           message.getLabel().contentEquals("Scientist") &&
-                                                           message.getContentType().contentEquals("application/json")) {
-
-                                                       byte[] body = message.getBody();
-                                                       Map scientist = GSON.fromJson(new String(body, UTF_8), Map.class);
-
-                                                       System.out.printf(
-                                                               "\n\t\t\t\tMessage received: \n\t\t\t\t\t\tMessageId = %s, \n\t\t\t\t\t\tSequenceNumber = %s, \n\t\t\t\t\t\tEnqueuedTimeUtc = %s," +
-                                                                       "\n\t\t\t\t\t\tExpiresAtUtc = %s, \n\t\t\t\t\t\tContentType = \"%s\",  \n\t\t\t\t\t\tContent: [ firstName = %s, name = %s ]\n",
-                                                               message.getMessageId(),
-                                                               message.getSequenceNumber(),
-                                                               message.getEnqueuedTimeUtc(),
-                                                               message.getExpiresAtUtc(),
-                                                               message.getContentType(),
-                                                               scientist != null ? scientist.get("firstName") : "",
-                                                               scientist != null ? scientist.get("name") : "");
-                                                   }
-                                                   return CompletableFuture.completedFuture(null);
-                                               }
-
-                                               // callback invoked when the message handler has an exception to report
-                                               public void notifyException(Throwable throwable, ExceptionPhase exceptionPhase) {
-                                                   System.out.printf(exceptionPhase + "-" + throwable.getMessage());
-                                               }
-                                           },
-                // 1 concurrent call, messages are auto-completed, auto-renew duration
-                new MessageHandlerOptions(1, true, Duration.ofMinutes(1)),
-                executorService);
-
+        // Close the sender
+        senderClient.close();
+        System.out.println("\nAll messages sent and client closed successfully.");
     }
 
     public static void main(String[] args) {
@@ -152,21 +110,6 @@ public class QueuesGettingStarted {
         } catch (Exception e) {
             System.out.printf("%s", e.toString());
             return 3;
-        }
-    }
-
-    private void waitForEnter(int seconds) {
-        ExecutorService executor = Executors.newCachedThreadPool();
-        try {
-            executor.invokeAny(Arrays.asList(() -> {
-                System.in.read();
-                return 0;
-            }, () -> {
-                Thread.sleep(seconds * 1000);
-                return 0;
-            }));
-        } catch (Exception e) {
-            // absorb
         }
     }
 }

--- a/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
+++ b/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
@@ -91,10 +91,7 @@ playground connector create-or-update --connector azure-service-bus-source  << E
     "azure.servicebus.max.waiting.time.seconds" : "30",
     "confluent.license": "",
     "confluent.topic.bootstrap.servers": "broker:9092",
-    "confluent.topic.replication.factor": "1",
-    "errors.tolerance": "all",
-    "errors.log.enable": "true",
-    "errors.log.include.messages": "true"
+    "confluent.topic.replication.factor": "1"
 }
 EOF
 

--- a/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
+++ b/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
@@ -73,12 +73,6 @@ AZURE_SAS_KEY=$(az servicebus namespace authorization-rule keys list \
     --namespace-name $AZURE_SERVICE_BUS_NAMESPACE \
     --name "RootManageSharedAccessKey" | jq -r '.primaryKey')
 
-# generate data file for externalizing secrets
-sed -e "s|:AZURE_SAS_KEY:|$AZURE_SAS_KEY|g" \
-    -e "s|:AZURE_SERVICE_BUS_NAMESPACE:|$AZURE_SERVICE_BUS_NAMESPACE|g" \
-    -e "s|:AZURE_SERVICE_BUS_QUEUE_NAME:|$AZURE_SERVICE_BUS_QUEUE_NAME|g" \
-    ../../connect/connect-azure-service-bus-source/data.template > ../../connect/connect-azure-service-bus-source/data
-
 PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
 playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"
 
@@ -89,9 +83,9 @@ playground connector create-or-update --connector azure-service-bus-source  << E
     "kafka.topic": "servicebus-topic",
     "tasks.max": "1",
     "azure.servicebus.sas.keyname": "RootManageSharedAccessKey",
-    "azure.servicebus.sas.key": "\${file:/data:AZURE_SAS_KEY}",
-    "azure.servicebus.namespace": "\${file:/data:AZURE_SERVICE_BUS_NAMESPACE}",
-    "azure.servicebus.entity.name": "\${file:/data:AZURE_SERVICE_BUS_QUEUE_NAME}",
+    "azure.servicebus.sas.key": "$AZURE_SAS_KEY",
+    "azure.servicebus.namespace": "$AZURE_SERVICE_BUS_NAMESPACE",
+    "azure.servicebus.entity.name": "$AZURE_SERVICE_BUS_QUEUE_NAME",
     "azure.servicebus.subscription" : "",
     "azure.servicebus.max.message.count" : "10",
     "azure.servicebus.max.waiting.time.seconds" : "30",

--- a/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
+++ b/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
@@ -103,5 +103,17 @@ docker exec -e SB_SAMPLES_CONNECTIONSTRING="$SB_SAMPLES_CONNECTIONSTRING" -e AZU
 
 sleep 180
 
+log "DEBUG: Listing all Kafka topics"
+docker exec broker kafka-topics --bootstrap-server broker:9092 --list 2>&1 || true
+
+log "DEBUG: Connect worker logs (last 100 lines)"
+docker logs connect --tail 100 2>&1 || true
+
+log "DEBUG: Connector config via REST API"
+docker exec connect curl -s http://localhost:8083/connectors/azure-service-bus-source/config 2>&1 || true
+
+log "DEBUG: Connector status via REST API"
+docker exec connect curl -s http://localhost:8083/connectors/azure-service-bus-source/status 2>&1 || true
+
 log "Verifying topic servicebus-topic"
 playground topic consume --topic servicebus-topic --min-expected-messages 5 --timeout 60

--- a/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
+++ b/connect/connect-azure-service-bus-source/azure-service-bus-source.sh
@@ -17,7 +17,7 @@ for component in QueuesGettingStarted
 do
      set +e
      log "🏗 Building jar for ${component}"
-     docker run -i --rm -e KAFKA_CLIENT_TAG=$KAFKA_CLIENT_TAG -e TAG=$TAG_BASE -v "${PWD}/${component}":/usr/src/mymaven -v "$HOME/.m2":/root/.m2 -v "$PWD/../../scripts/settings.xml:/tmp/settings.xml" -v "${PWD}/${component}/target:/usr/src/mymaven/target" -w /usr/src/mymaven maven:3.6.1-jdk-11 mvn -s /tmp/settings.xml -Dkafka.tag=$TAG -Dkafka.client.tag=$KAFKA_CLIENT_TAG package > /tmp/result.log 2>&1
+     docker run -i --rm -e KAFKA_CLIENT_TAG=$KAFKA_CLIENT_TAG -e TAG=$TAG_BASE -v "${PWD}/${component}":/usr/src/mymaven -v "$HOME/.m2":/root/.m2 -v "$PWD/../../scripts/settings.xml:/tmp/settings.xml" -v "${PWD}/${component}/target:/usr/src/mymaven/target" -w /usr/src/mymaven maven:3.9.11-eclipse-temurin-11 mvn -s /tmp/settings.xml -Dkafka.tag=$TAG -Dkafka.client.tag=$KAFKA_CLIENT_TAG package > /tmp/result.log 2>&1
      if [ $? != 0 ]
      then
           logerror "❌ failed to build java component $component"
@@ -101,19 +101,7 @@ log "Inject data in Service Bus, using QueuesGettingStarted java program"
 SB_SAMPLES_CONNECTIONSTRING="Endpoint=sb://$AZURE_SERVICE_BUS_NAMESPACE.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=$AZURE_SAS_KEY"
 docker exec -e SB_SAMPLES_CONNECTIONSTRING="$SB_SAMPLES_CONNECTIONSTRING" -e AZURE_SERVICE_BUS_QUEUE_NAME="$AZURE_SERVICE_BUS_QUEUE_NAME" simple-send bash -c "java -jar queuesgettingstarted-1.0.0-jar-with-dependencies.jar"
 
-sleep 180
-
-log "DEBUG: Listing all Kafka topics"
-docker exec broker kafka-topics --bootstrap-server broker:9092 --list 2>&1 || true
-
-log "DEBUG: Connect worker logs (last 100 lines)"
-docker logs connect --tail 100 2>&1 || true
-
-log "DEBUG: Connector config via REST API"
-docker exec connect curl -s http://localhost:8083/connectors/azure-service-bus-source/config 2>&1 || true
-
-log "DEBUG: Connector status via REST API"
-docker exec connect curl -s http://localhost:8083/connectors/azure-service-bus-source/status 2>&1 || true
+sleep 15
 
 log "Verifying topic servicebus-topic"
 playground topic consume --topic servicebus-topic --min-expected-messages 5 --timeout 60

--- a/connect/connect-azure-service-bus-source/docker-compose.plaintext.yml
+++ b/connect/connect-azure-service-bus-source/docker-compose.plaintext.yml
@@ -1,8 +1,6 @@
 ---
 services:
   connect:
-    volumes:
-      - ../../connect/connect-azure-service-bus-source/data:/data
     environment:
       CONNECT_PLUGIN_PATH: /usr/share/confluent-hub-components/confluentinc-kafka-connect-azure-service-bus
 

--- a/connect/connect-azure-service-bus-source/docker-compose.plaintext.yml
+++ b/connect/connect-azure-service-bus-source/docker-compose.plaintext.yml
@@ -7,13 +7,11 @@ services:
       CONNECT_PLUGIN_PATH: /usr/share/confluent-hub-components/confluentinc-kafka-connect-azure-service-bus
 
   simple-send:
-    build:
-      context: ../../connect/connect-azure-service-bus-source/QueuesGettingStarted/
-      args:
-        CP_CONNECT_TAG: ${CP_CONNECT_TAG}
-        CP_CONNECT_IMAGE: ${CP_CONNECT_IMAGE}
-        KAFKA_CLIENT_TAG: ${KAFKA_CLIENT_TAG}
+    image: eclipse-temurin:11-jre
     hostname: simple-send
     container_name: simple-send
+    volumes:
+      - ../../connect/connect-azure-service-bus-source/QueuesGettingStarted/target/queuesgettingstarted-1.0.0-jar-with-dependencies.jar:/queuesgettingstarted-1.0.0-jar-with-dependencies.jar:ro
+    command: ["sleep", "infinity"]
     depends_on:
       - broker


### PR DESCRIPTION
## Summary
- Replace `CP_CONNECT_IMAGE` base with `eclipse-temurin:11-jre` in the `simple-send` sidecar Dockerfile
- Remove unused `CP_CONNECT_TAG`, `CP_CONNECT_IMAGE`, `KAFKA_CLIENT_TAG` build args from docker-compose

## Problem
The `simple-send` container used `${CP_CONNECT_IMAGE}:${CP_CONNECT_TAG}` as its base image. On Semaphore CI, the default buildx builder uses a `docker-container` (remote) driver which cannot pull the CP connect image, resulting in:
```
building with "buildx-builder" instance using remote driver
[internal] waiting for connection
ERROR: context deadline exceeded
```
This causes KDP gating tests to fail for [kafka-connect-azure-service-bus PR #120](https://github.com/confluentinc/kafka-connect-azure-service-bus/pull/120).

## Fix
The `simple-send` container only runs `java -jar queuesgettingstarted-1.0.0-jar-with-dependencies.jar` — it doesn't need the full CP connect image. Switching to `eclipse-temurin:11-jre` (a lightweight public JRE image) eliminates the problematic pull and makes the build faster.

## Test plan
- [ ] Retrigger KDP gating test on kafka-connect-azure-service-bus PR #120 after merge