### PR TITLE
Skip top-of-script version guards when CONNECTOR_TAG is empty

### DIFF
--- a/connect/connect-aws-s3-source/s3-source-backup-and-restore-with-assuming-iam-role-config.sh
+++ b/connect/connect-aws-s3-source/s3-source-backup-and-restore-with-assuming-iam-role-config.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if ! version_gt $CONNECTOR_TAG "2.5.0"; then
+if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "2.5.0"; then
     logwarn "this is available since version 2.5.1 only"
     exit 1
 fi

--- a/connect/connect-aws-s3-source/s3-source-generalized.sh
+++ b/connect/connect-aws-s3-source/s3-source-generalized.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if ! version_gt $CONNECTOR_TAG "1.9.9"; then
+if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "1.9.9"; then
     # skipped
     logwarn "skipped as it requires connector version 2.0.0"
     exit 111

--- a/connect/connect-azure-blob-storage-source/azure-blob-storage-source-generalized.sh
+++ b/connect/connect-azure-blob-storage-source/azure-blob-storage-source-generalized.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if ! version_gt $CONNECTOR_TAG "2.1.99"; then
+if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "2.1.99"; then
     # skipped
     logwarn "skipped as it requires connector version 2.2.0"
     exit 111

--- a/connect/connect-gcp-gcs-source/gcs-source-generalized.sh
+++ b/connect/connect-gcp-gcs-source/gcs-source-generalized.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../../scripts/utils.sh
 
-if ! version_gt $CONNECTOR_TAG "2.0.99"; then
+if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "2.0.99"; then
     # skipped
     logwarn "skipped as it requires connector version 2.1.0"
     exit 111


### PR DESCRIPTION
## Problem

Several connector test scripts have a top-of-script guard of the form:

```bash
if ! version_gt $CONNECTOR_TAG "X.Y.Z"; then
    logwarn "skipped as it requires connector version A.B.C"
    exit 111
fi
```

When a test is invoked with `--connector-zip` (instead of `--connector-tag`), `CONNECTOR_TAG` is unset. `version_gt` is implemented as:

```bash
version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
```

`printf '%s\n' "" "1.9.9" | sort -V` puts the empty string first, so `head -n 1` is `""`, the `test "" != ""` fails, `version_gt` returns false, the `! version_gt` guard trips, and the script exits 111 — even though the local zip is the version under test and should run.

Other guards in the same scripts (the CP-version Block 3 guards) already use `[ ! -z "$CONNECTOR_TAG" ] && version_gt …`, treating an unknown tag as "no constraint." This PR applies the same pattern to the buggy top-of-script guards.

## Repro

confluentinc/connect-ci-cd-pipelines `run_kdp_matrix_on_pr_builds.yml` invokes:

```yaml
yes | playground run -f $TEST_SCRIPT
```

…with `CONNECTOR_ZIP` set (pointing at the locally built connector) and `CONNECTOR_TAG` unset. Every connector PR running against `kafka-connect-object-store-source` (e.g. [PR #725](https://github.com/confluentinc/kafka-connect-object-store-source/pull/725)) hits these guards and silently skips the actual end-to-end test — the wrapper records exit 111 as a failed entry in `failed_tests.txt`, so the pipeline overall fails on what is really a never-run test.

Workflow showing the pre-fix behavior: https://semaphore.ci.confluent.io/workflows/fdff8a1d-c2bf-4e56-8050-712987a9cdc6 — `s3-source-generalized.sh`, `azure-blob-storage-source-generalized.sh`, `gcs-source-generalized.sh` all skip with `❗ skipped as it requires connector version X.Y.Z`.

## Fix

Add `[ ! -z "$CONNECTOR_TAG" ] &&` to the four affected guards:

| File | Old | New |
|---|---|---|
| `connect/connect-aws-s3-source/s3-source-generalized.sh` | `if ! version_gt $CONNECTOR_TAG "1.9.9"` | `if [ ! -z "$CONNECTOR_TAG" ] && ! version_gt $CONNECTOR_TAG "1.9.9"` |
| `connect/connect-aws-s3-source/s3-source-backup-and-restore-with-assuming-iam-role-config.sh` | `if ! version_gt $CONNECTOR_TAG "2.5.0"` | same wrap |
| `connect/connect-azure-blob-storage-source/azure-blob-storage-source-generalized.sh` | `if ! version_gt $CONNECTOR_TAG "2.1.99"` | same wrap |
| `connect/connect-gcp-gcs-source/gcs-source-generalized.sh` | `if ! version_gt $CONNECTOR_TAG "2.0.99"` | same wrap |

## Behavioral effect

- `--connector-tag X.Y.Z` runs (CONNECTOR_TAG set, comparison done as before).
- `--connector-zip /path/to/zip` runs (CONNECTOR_TAG empty, guard skipped, test proceeds).
- Zip with a too-old plugin internally is no longer caught by the version-gate, but the test will fail later on missing functionality, which is the same outcome and gives clearer signal than a silent skip.

## Out of scope

- Other version guards in this script that already check for `$CONNECTOR_TAG` emptiness (Block 2/3) — already correct.
- `connect/connect-hdfs3-sink/hdfs3-sink.sh:82` — same pattern but different semantics (the body branches into legacy beeline behavior, not an early exit). Behavior with empty tag is "fall through to legacy path", which is benign. Not changed here.
- An upstream fix in `scripts/cli/src/commands/run.sh` that auto-derives `CONNECTOR_TAG` from the zip's `manifest.json` — would let the version guards remain strict. Larger change; left for a follow-up.

## Testing done

- `mvn`-built connector zip from kafka-connect-object-store-source `user/sharan/update_parent` invokes the guard correctly post-fix:
  ```
  $ CONNECTOR_TAG="" version_gt "" "1.9.9" && echo TRUE || echo FALSE
  FALSE   ← old behavior (would skip)
  $ [ ! -z "$CONNECTOR_TAG" ] && ! version_gt "" "1.9.9" && echo SKIP || echo PROCEED
  PROCEED ← new behavior
  ```
- Will validate end-to-end via the connector PR's KDP run once this lands and the runner pipeline points at the patched fork.
