### PR TITLE
gcp spanner data verification retries

### DIFF
--- a/connect/connect-gcp-spanner-sink/gcp-spanner-sink.sh
+++ b/connect/connect-gcp-spanner-sink/gcp-spanner-sink.sh
@@ -140,6 +140,19 @@ EOF
 sleep 60
 
 log "Verify data is in GCP Spanner"
-docker run -i --volumes-from gcloud-config google/cloud-sdk:latest gcloud spanner databases execute-sql $GCP_SPANNER_DATABASE --instance $GCP_SPANNER_INSTANCE --project $GCP_PROJECT --sql='select * from kafka_products' > /tmp/result.log  2>&1
-cat /tmp/result.log
-grep "notebooks" /tmp/result.log
+max_retries=2
+retry=0
+while true; do
+  sleep 5
+  docker run -i --volumes-from gcloud-config google/cloud-sdk:latest gcloud spanner databases execute-sql $GCP_SPANNER_DATABASE --instance $GCP_SPANNER_INSTANCE --project $GCP_PROJECT --sql='select * from kafka_products' > /tmp/result.log  2>&1
+  cat /tmp/result.log
+  if grep -q "notebooks" /tmp/result.log; then
+    break
+  fi
+  retry=$((retry+1))
+  if [ $retry -gt $max_retries ]; then
+    logerror "❌ 'notebooks' not found in GCP Spanner after $max_retries retries"
+    exit 1
+  fi
+  log "🔄 'notebooks' not found yet, retrying ($retry/$max_retries)..."
+done

--- a/connect/connect-gcp-spanner-sink/gcp-spanner-sink.sh
+++ b/connect/connect-gcp-spanner-sink/gcp-spanner-sink.sh
@@ -144,7 +144,7 @@ max_retries=2
 retry=0
 while true; do
   sleep 5
-  docker run -i --volumes-from gcloud-config google/cloud-sdk:latest gcloud spanner databases execute-sql $GCP_SPANNER_DATABASE --instance $GCP_SPANNER_INSTANCE --project $GCP_PROJECT --sql='select * from kafka_products' > /tmp/result.log  2>&1
+  docker run -i --rm --volumes-from gcloud-config google/cloud-sdk:latest gcloud spanner databases execute-sql $GCP_SPANNER_DATABASE --instance $GCP_SPANNER_INSTANCE --project $GCP_PROJECT --sql='select * from kafka_products' > /tmp/result.log 2>&1
   cat /tmp/result.log
   if grep -q "notebooks" /tmp/result.log; then
     break


### PR DESCRIPTION
⏺ Add retries to GCP Spanner sink data verification                                                                                                                                                              
                                                                                                                                                                                                                 
Fixes flaky CI failures in connect-gcp-spanner-sink where data verification ran before the connector finished writing records to Spanner. Adds a 5s sleep + up to 2 retries on the verification query (loops until the expected notebooks record appears), and uses --rm so retry attempts don't leave containers behind. Local runs already passed thanks to extra wait time; this makes CI consistent.