### PR TITLE
Build GCP Firebase database reference from region for firebase sink/source connectors

### DIFF
--- a/connect/connect-gcp-firebase-sink/README.md
+++ b/connect/connect-gcp-firebase-sink/README.md
@@ -57,6 +57,8 @@ Simply run:
 $ just use <playground run> command and search for gcp-firebase-source<use tab key to activate fzf completion (see https://kafka-docker-playground.io/#/cli?id=%e2%9a%a1-setup-completion), otherwise use full path, or correct relative path> .sh in this folder
 ```
 
+`gcp.firebase.database.reference` is built from `GCP_PROJECT` and the region argument, e.g. `https://<GCP_PROJECT>-default-rtdb.<region>.firebasedatabase.app/musicBlog`. Pass `us-central1` as the region argument for legacy databases using the `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format instead.
+
 ### Verify data has been pushed to Firebase
 
 Note: this is now automated.

--- a/connect/connect-gcp-firebase-sink/gcp-firebase-sink.sh
+++ b/connect/connect-gcp-firebase-sink/gcp-firebase-sink.sh
@@ -17,6 +17,14 @@ then
      exit 1
 fi
 
+GCP_FIREBASE_REGION=${1:-europe-west1}
+if [ "$GCP_FIREBASE_REGION" == "us-central1" ]
+then
+     GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}.firebaseio.com/musicBlog"
+else
+     GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}-default-rtdb.${GCP_FIREBASE_REGION}.firebasedatabase.app/musicBlog"
+fi
+
 cd ../../connect/connect-gcp-firebase-sink
 GCP_KEYFILE="${PWD}/keyfile.json"
 if [ ! -f ${GCP_KEYFILE} ] && [ -z "$GCP_KEYFILE_CONTENT" ]
@@ -47,7 +55,7 @@ playground connector create-or-update --connector firebase-sink  << EOF
   "tasks.max" : "1",
   "topics":"artists,songs",
   "gcp.firebase.credentials.path": "/tmp/keyfile.json",
-  "gcp.firebase.database.reference": "https://$GCP_PROJECT.firebaseio.com/musicBlog",
+  "gcp.firebase.database.reference": "${GCP_FIREBASE_DATABASE_REFERENCE}",
   "insert.mode":"update",
   "key.converter": "org.apache.kafka.connect.storage.StringConverter",
   "value.converter" : "io.confluent.connect.avro.AvroConverter",

--- a/connect/connect-gcp-firebase-source/README.md
+++ b/connect/connect-gcp-firebase-source/README.md
@@ -69,3 +69,5 @@ Simply run:
 ```bash
 $ just use <playground run> command and search for gcp-firebase-source<use tab key to activate fzf completion (see https://kafka-docker-playground.io/#/cli?id=%e2%9a%a1-setup-completion), otherwise use full path, or correct relative path> .sh in this folder
 ```
+
+`gcp.firebase.database.reference` is built from `GCP_PROJECT` and the region argument, e.g. `https://<GCP_PROJECT>-default-rtdb.<region>.firebasedatabase.app/musicBlog`. Pass `us-central1` as the region argument for legacy databases using the `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format instead.

--- a/connect/connect-gcp-firebase-source/gcp-firebase-source.sh
+++ b/connect/connect-gcp-firebase-source/gcp-firebase-source.sh
@@ -34,6 +34,14 @@ else
 fi
 cd -
 
+GCP_FIREBASE_REGION=${1:-europe-west1}
+if [ "$GCP_FIREBASE_REGION" == "us-central1" ]
+then
+     GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}.firebaseio.com/musicBlog"
+else
+     GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}-default-rtdb.${GCP_FIREBASE_REGION}.firebasedatabase.app/musicBlog"
+fi
+
 log "Removing all data"
 docker run -p 9005:9005 -v $PWD/../../connect/connect-gcp-firebase-source/keyfile.json:/tmp/keyfile.json -e GOOGLE_APPLICATION_CREDENTIALS="/tmp/keyfile.json" -e PROJECT=$GCP_PROJECT -i andreysenov/firebase-tools firebase database:remove / --project "$GCP_PROJECT" --force
 log "Adding data from musicBlog.json"
@@ -50,7 +58,7 @@ playground connector create-or-update --connector firebase-source  << EOF
     "connector.class" : "io.confluent.connect.firebase.FirebaseSourceConnector",
     "tasks.max" : "1",
     "gcp.firebase.credentials.path": "/tmp/keyfile.json",
-    "gcp.firebase.database.reference": "https://$GCP_PROJECT.firebaseio.com/musicBlog",
+    "gcp.firebase.database.reference": "${GCP_FIREBASE_DATABASE_REFERENCE}",
     "gcp.firebase.snapshot":"true",
     "confluent.topic.bootstrap.servers": "broker:9092",
     "confluent.topic.replication.factor": "1",


### PR DESCRIPTION
## Summary
- Pass `us-central1` as the region argument to keep using the legacy `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format; any other region builds `https://<GCP_PROJECT>-default-rtdb.<region>.firebasedatabase.app/musicBlog`.
- Applies to both `connect-gcp-firebase-sink` and `connect-gcp-firebase-source`, with matching README notes.
