### PR TITLE
Fix GCP_FIREBASE_REGION to read from environment variable

### DIFF
--- a/connect/connect-gcp-firebase-sink/README.md
+++ b/connect/connect-gcp-firebase-sink/README.md
@@ -57,7 +57,7 @@ Simply run:
 $ just use <playground run> command and search for gcp-firebase-source<use tab key to activate fzf completion (see https://kafka-docker-playground.io/#/cli?id=%e2%9a%a1-setup-completion), otherwise use full path, or correct relative path> .sh in this folder
 ```
 
-`gcp.firebase.database.reference` is built from `GCP_PROJECT` and the region argument, e.g. `https://<GCP_PROJECT>-default-rtdb.<region>.firebasedatabase.app/musicBlog`. Pass `us-central1` as the region argument for legacy databases using the `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format instead.
+`gcp.firebase.database.reference` is built from `GCP_PROJECT` and the `GCP_FIREBASE_REGION` environment variable (defaults to `europe-west1`), e.g. `https://<GCP_PROJECT>-default-rtdb.<GCP_FIREBASE_REGION>.firebasedatabase.app/musicBlog`. Set `GCP_FIREBASE_REGION` to `us-central1` for legacy databases using the `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format instead.
 
 ### Verify data has been pushed to Firebase
 

--- a/connect/connect-gcp-firebase-sink/gcp-firebase-sink.sh
+++ b/connect/connect-gcp-firebase-sink/gcp-firebase-sink.sh
@@ -17,7 +17,7 @@ then
      exit 1
 fi
 
-GCP_FIREBASE_REGION=${1:-europe-west1}
+GCP_FIREBASE_REGION=${GCP_FIREBASE_REGION:-europe-west1}
 if [ "$GCP_FIREBASE_REGION" == "us-central1" ]
 then
      GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}.firebaseio.com/musicBlog"

--- a/connect/connect-gcp-firebase-source/README.md
+++ b/connect/connect-gcp-firebase-source/README.md
@@ -70,4 +70,4 @@ Simply run:
 $ just use <playground run> command and search for gcp-firebase-source<use tab key to activate fzf completion (see https://kafka-docker-playground.io/#/cli?id=%e2%9a%a1-setup-completion), otherwise use full path, or correct relative path> .sh in this folder
 ```
 
-`gcp.firebase.database.reference` is built from `GCP_PROJECT` and the region argument, e.g. `https://<GCP_PROJECT>-default-rtdb.<region>.firebasedatabase.app/musicBlog`. Pass `us-central1` as the region argument for legacy databases using the `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format instead.
+`gcp.firebase.database.reference` is built from `GCP_PROJECT` and the `GCP_FIREBASE_REGION` environment variable (defaults to `europe-west1`), e.g. `https://<GCP_PROJECT>-default-rtdb.<GCP_FIREBASE_REGION>.firebasedatabase.app/musicBlog`. Set `GCP_FIREBASE_REGION` to `us-central1` for legacy databases using the `https://<GCP_PROJECT>.firebaseio.com/musicBlog` format instead.

--- a/connect/connect-gcp-firebase-source/gcp-firebase-source.sh
+++ b/connect/connect-gcp-firebase-source/gcp-firebase-source.sh
@@ -34,7 +34,7 @@ else
 fi
 cd -
 
-GCP_FIREBASE_REGION=${1:-europe-west1}
+GCP_FIREBASE_REGION=${GCP_FIREBASE_REGION:-europe-west1}
 if [ "$GCP_FIREBASE_REGION" == "us-central1" ]
 then
      GCP_FIREBASE_DATABASE_REFERENCE="https://${GCP_PROJECT}.firebaseio.com/musicBlog"


### PR DESCRIPTION
## Summary
- `GCP_FIREBASE_REGION=${1:-europe-west1}` read the script's positional argument `$1`, not the `GCP_FIREBASE_REGION` environment variable of the same name. Since `playground run` always invokes test scripts as `bash $filename` with no arguments, `$1` was always empty, so the region was silently hardcoded to `europe-west1` regardless of any exported `GCP_FIREBASE_REGION`.
- Changed to `GCP_FIREBASE_REGION=${GCP_FIREBASE_REGION:-europe-west1}` in both `connect/connect-gcp-firebase-source/gcp-firebase-source.sh` and `connect/connect-gcp-firebase-sink/gcp-firebase-sink.sh` so the env var is actually respected, falling back to `europe-west1` when unset.
- Updated both READMEs, which described a "region argument" left over from the original design, to reflect that this is an environment variable.
