### PR TITLE
Extend RabbitMQ source/sink KDP tests for queue<->topic mapping

### DIFF
--- a/connect/connect-rabbitmq-sink/rabbitmq-sink.sh
+++ b/connect/connect-rabbitmq-sink/rabbitmq-sink.sh
@@ -53,3 +53,56 @@ log "Check messages received in RabbitMQ"
 docker exec -i rabbitmq rabbitmqadmin -u myuser -p mypassword get queue=queue1 count=10 > /tmp/result.log  2>&1
 cat /tmp/result.log
 grep "rkey1" /tmp/result.log
+
+####################################################################################
+# topic -> queue mapping with fallback.
+#   3 topics (topic-a, topic-b, topic-c) x 5 messages
+#   map: topic-a->qa, topic-b->qb ; topic-c falls back to amq.direct/fallback-rk -> qc-fallback
+####################################################################################
+log "Provisioning queues qa, qb, and qc-fallback (bound to amq.direct/fallback-rk)"
+docker exec -i rabbitmq rabbitmqadmin -u myuser -p mypassword -V / declare queue name=qa durable=true
+docker exec -i rabbitmq rabbitmqadmin -u myuser -p mypassword -V / declare queue name=qb durable=true
+docker exec -i rabbitmq rabbitmqadmin -u myuser -p mypassword -V / declare queue name=qc-fallback durable=true
+docker exec -i rabbitmq rabbitmqadmin -u myuser -p mypassword -V / declare binding source=amq.direct destination=qc-fallback routing_key=fallback-rk
+
+log "Producing 5 messages to each of topic-a, topic-b, topic-c"
+for t in topic-a topic-b topic-c; do
+  playground topic produce -t ${t} --nb-messages 5 << 'EOF'
+%g
+EOF
+done
+
+log "Creating sink connector (partial topic->queue map + fallback exchange)"
+playground connector create-or-update --connector rabbitmq-sink-map << EOF
+{
+  "connector.class": "io.confluent.connect.rabbitmq.sink.RabbitMQSinkConnector",
+  "tasks.max": "1",
+  "topics": "topic-a,topic-b,topic-c",
+  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+  "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+  "rabbitmq.topic.queue.map": "{\"topic-a\":\"qa\",\"topic-b\":\"qb\"}",
+  "rabbitmq.exchange": "amq.direct",
+  "rabbitmq.routing.key": "fallback-rk",
+  "rabbitmq.delivery.mode": "PERSISTENT",
+  "rabbitmq.host": "rabbitmq",
+  "rabbitmq.username": "myuser",
+  "rabbitmq.password": "mypassword",
+  "confluent.topic.bootstrap.servers": "broker:9092",
+  "confluent.topic.replication.factor": "1"
+}
+EOF
+
+sleep 15
+
+log "Asserting queue depths: qa=5 (topic-a), qb=5 (topic-b), qc-fallback=5 (topic-c fallback)"
+for pair in "qa 5" "qb 5" "qc-fallback 5"; do
+  q=$(echo "$pair" | awk '{print $1}')
+  expected=$(echo "$pair" | awk '{print $2}')
+  actual=$(docker exec rabbitmq rabbitmqctl -q -p "/" list_queues name messages | awk -v Q="${q}" '$1==Q{print $2}')
+  if [ "$actual" != "$expected" ]; then
+    logerror "queue ${q} has '${actual}' messages, expected ${expected}"
+    exit 1
+  fi
+  log "  ${q}: ${actual} messages"
+done
+log "topic->queue mapping scenario verified (map + fallback)"

--- a/connect/connect-rabbitmq-source/rabbitmq-source.sh
+++ b/connect/connect-rabbitmq-source/rabbitmq-source.sh
@@ -42,3 +42,96 @@ playground topic consume --topic rabbitmq --min-expected-messages 5 --timeout 60
 
 #log "Consume messages in RabbitMQ"
 #docker exec -i rabbitmq_consumer bash -c "python /consumer.py myqueue"
+
+####################################################################################
+# queue -> topic mapping, task partitioning, and consumer modes.
+####################################################################################
+
+# Scenario A - dedicated mode (default): queue->topic map + fallback, with task
+# partitioning bounded by rabbitmq.max.queue.per.task.
+#   4 queues, tasks.max=2, max.queue.per.task=2
+#   map: q1->topic-a, q2->topic-b ; q3,q4 fall back to kafka.topic=topic-fallback
+log "[A] dedicated: publishing 5 messages to each of q1..q4"
+for q in q1 q2 q3 q4; do
+  docker exec rabbitmq_producer bash -c "python /producer.py ${q} 5"
+done
+
+log "[A] creating source connector (4 queues, tasks.max=2, max.queue.per.task=2, partial map)"
+playground connector create-or-update --connector rabbitmq-source-map << EOF
+{
+  "connector.class": "io.confluent.connect.rabbitmq.RabbitMQSourceConnector",
+  "tasks.max": "2",
+  "kafka.topic": "topic-fallback",
+  "rabbitmq.queue": "q1,q2,q3,q4",
+  "rabbitmq.queue.topic.map": "{\"q1\":\"topic-a\",\"q2\":\"topic-b\"}",
+  "rabbitmq.max.queue.per.task": "2",
+  "rabbitmq.host": "rabbitmq",
+  "rabbitmq.username": "myuser",
+  "rabbitmq.password": "mypassword",
+  "confluent.topic.bootstrap.servers": "broker:9092",
+  "confluent.topic.replication.factor": "1"
+}
+EOF
+
+log "[A] waiting for tasks to subscribe"
+sleep 10
+
+log "[A] per-task queue assignment (informational)"
+docker exec connect curl -s http://localhost:8083/connectors/rabbitmq-source-map/tasks \
+  | jq -c '.[] | {task: .id.task, queues: (.config["rabbitmq.queue"] | split(","))}'
+
+# dedicated mode -> each queue is consumed by exactly ONE task
+log "[A] asserting each queue has exactly 1 consumer (dedicated topology)"
+for q in q1 q2 q3 q4; do
+  c=$(docker exec rabbitmq rabbitmqctl -q -p "/" list_queues name consumers | awk -v Q="${q}" '$1==Q{print $2}')
+  if [ "$c" != "1" ]; then
+    logerror "[A] queue ${q} has '${c}' consumers, expected 1 (dedicated mode)"
+    exit 1
+  fi
+done
+
+log "[A] verify routing: q1 -> topic-a (5), q2 -> topic-b (5), q3+q4 -> topic-fallback (10)"
+playground topic consume --topic topic-a --min-expected-messages 5 --timeout 60
+playground topic consume --topic topic-b --min-expected-messages 5 --timeout 60
+playground topic consume --topic topic-fallback --min-expected-messages 10 --timeout 60
+
+# Scenario B - shared mode: every task subscribes to every queue. Contrast with
+# dedicated: each queue should have tasks.max consumers, not 1. Per-queue ordering
+# is intentionally NOT preserved in this mode.
+# Publish BEFORE creating the connector so the queues exist (fail-fast default).
+log "[B] shared: publishing 5 messages to each of s1,s2 (also declares the queues)"
+docker exec rabbitmq_producer bash -c "python /producer.py s1 5"
+docker exec rabbitmq_producer bash -c "python /producer.py s2 5"
+
+log "[B] creating source connector (2 queues, tasks.max=2, consumer.mode=shared)"
+playground connector create-or-update --connector rabbitmq-source-shared << EOF
+{
+  "connector.class": "io.confluent.connect.rabbitmq.RabbitMQSourceConnector",
+  "tasks.max": "2",
+  "kafka.topic": "rabbitmq-shared",
+  "rabbitmq.queue": "s1,s2",
+  "rabbitmq.queue.consumer.mode": "shared",
+  "rabbitmq.host": "rabbitmq",
+  "rabbitmq.username": "myuser",
+  "rabbitmq.password": "mypassword",
+  "confluent.topic.bootstrap.servers": "broker:9092",
+  "confluent.topic.replication.factor": "1"
+}
+EOF
+
+log "[B] waiting for tasks to subscribe"
+sleep 10
+
+log "[B] asserting each queue has tasks.max (2) consumers (shared topology)"
+for q in s1 s2; do
+  c=$(docker exec rabbitmq rabbitmqctl -q -p "/" list_queues name consumers | awk -v Q="${q}" '$1==Q{print $2}')
+  if [ "$c" != "2" ]; then
+    logerror "[B] queue ${q} has '${c}' consumers, expected 2 (shared mode)"
+    exit 1
+  fi
+done
+
+log "[B] verify all 10 messages (s1:5 + s2:5) reached topic rabbitmq-shared"
+playground topic consume --topic rabbitmq-shared --min-expected-messages 10 --timeout 60
+
+log "queue->topic mapping scenarios verified (dedicated map/partitioning + shared mode)"


### PR DESCRIPTION
Extends the canonical `rabbitmq-source.sh` / `rabbitmq-sink.sh` in place (no new folders) with scenarios covering the new per-queue/topic routing.

**Source** (`connect/connect-rabbitmq-source/rabbitmq-source.sh`)
- dedicated (default): partial `rabbitmq.queue.topic.map` + fallback (`kafka.topic`); task partitioning with `rabbitmq.max.queue.per.task`. Asserts 1 consumer/queue (dedicated topology) and correct per-queue -> topic routing; logs the per-task queue assignment for debugging.
- shared: `rabbitmq.queue.consumer.mode=shared` — asserts tasks.max consumers/queue and end-to-end data flow.

**Sink** (`connect/connect-rabbitmq-sink/rabbitmq-sink.sh`)
- partial `rabbitmq.topic.queue.map` + fallback exchange/routing key; asserts per-queue message depths.

**Validation:** run locally against connector `1.8.5` on CP `8.0.0` — both scripts pass.