### PR TITLE
Fix SplunkSinkTest: disable HEC SSL enforcement in test connector config

### DIFF
--- a/connect/connect-splunk-sink/splunk-sink-formatted.sh
+++ b/connect/connect-splunk-sink/splunk-sink-formatted.sh
@@ -45,6 +45,7 @@ playground connector create-or-update --connector splunk-sink  << EOF
      "splunk.indexes": "main",
      "splunk.hec.uri": "http://splunk:8088",
      "splunk.hec.token": "99582090-3ac3-4db1-9487-e17b17a05081",
+     "splunk.hec.ssl.enforced": "false",
      "splunk.hec.json.event.formatted": "true",
      "splunk.hec.max.batch.size": "1",
      "splunk.sourcetypes": "my_sourcetype",

--- a/connect/connect-splunk-sink/splunk-sink.sh
+++ b/connect/connect-splunk-sink/splunk-sink.sh
@@ -40,6 +40,7 @@ playground connector create-or-update --connector splunk-sink  << EOF
      "splunk.indexes": "main",
      "splunk.hec.uri": "http://splunk:8088",
      "splunk.hec.token": "99582090-3ac3-4db1-9487-e17b17a05081",
+     "splunk.hec.ssl.enforced": "false",
      "splunk.sourcetypes": "my_sourcetype",
      "value.converter":"org.apache.kafka.connect.json.JsonConverter",
      "value.converter.schemas.enable":"false"


### PR DESCRIPTION
## Summary
- The Splunk Sink Connector plugin (v2.2.7) added SSL enforcement validation that rejects a plaintext HEC URI (`http://splunk:8088`) unless `splunk.hec.ssl.enforced` is explicitly set to `false`.
- The test's Splunk instance intentionally runs HEC without TLS (`hec.ssl: False` in `connect/connect-splunk-sink/default.yml`), so add `"splunk.hec.ssl.enforced": "false"` to the connector config in both `splunk-sink.sh` and `splunk-sink-formatted.sh`.

## Test plan
- [x] Run `connect/connect-splunk-sink/splunk-sink.sh` and confirm the connector reaches `RUNNING` without the `Invalid HEC transport configuration` error, and the `Sword of Honour` assertion passes.
- [x] Run `connect/connect-splunk-sink/splunk-sink-formatted.sh` and confirm the `000013934` assertion passes.

Fixes CC-43421

🤖 Generated with [Claude Code](https://claude.com/claude-code)